### PR TITLE
Replace deprecated `ugettext` with `gettext`

### DIFF
--- a/django_admin_inline_paginator/apps.py
+++ b/django_admin_inline_paginator/apps.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 from django.apps import AppConfig
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 class DjangoAdminInlinePaginatorConfig(AppConfig):

--- a/django_admin_inline_paginator/tests/apps_test.py
+++ b/django_admin_inline_paginator/tests/apps_test.py
@@ -1,6 +1,6 @@
 import unittest
 from django.apps import AppConfig
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django_admin_inline_paginator.apps import DjangoAdminInlinePaginatorConfig
 
 


### PR DESCRIPTION
## What I did

When using this package locally with certain versions of Django, a deprecation warning comes up:

> RemovedInDjango40Warning: django.utils.translation.ugettext_lazy() is deprecated in favor of django.utils.translation.gettext_lazy().

The use of `ugettext_lazy` was deprecated in [Django 3.0](https://docs.djangoproject.com/en/dev/releases/3.0/#features-deprecated-in-3-0) and will be removed in 4.0, which is soon to be released.

All currently supported Django versions (2.2 LTS and above) support `gettext_lazy`, so this should not be a breaking change.

## How to test

All tests should pass! No change in the package's behavior is expected.