### PR TITLE
Add type hints to `django_admin_inline_paginator` module

### DIFF
--- a/django_admin_inline_paginator/__init__.py
+++ b/django_admin_inline_paginator/__init__.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 try:
     import django
+
+    if django.VERSION < (3, 2):  # pragma: no cover
+        default_app_config = 'django_admin_inline_paginator.apps.DjangoAdminInlinePaginatorConfig'
 except ImportError:
-    django = None
+    pass
 
 __version__ = '0.2.2'
-
-if django and django.VERSION < (3, 2):  # pragma: no cover
-    default_app_config = 'django_admin_inline_paginator.apps.DjangoAdminInlinePaginatorConfig'

--- a/django_admin_inline_paginator/admin.py
+++ b/django_admin_inline_paginator/admin.py
@@ -1,9 +1,12 @@
+from typing import Optional
 from django.contrib.admin import TabularInline
 from django.contrib.admin.views.main import ChangeList
-from django.core.paginator import EmptyPage, InvalidPage, Paginator
+from django.core.paginator import Paginator
+from django.http import HttpRequest
+from django.db.models import QuerySet
 
 
-class InlineChangeList(object):
+class InlineChangeList:
     """
         Used by template to construct the paginator
     """
@@ -11,7 +14,7 @@ class InlineChangeList(object):
     multi_page = True
     get_query_string = ChangeList.__dict__['get_query_string']
 
-    def __init__(self, request, page_num, paginator):
+    def __init__(self, request: HttpRequest, page_num: int, paginator: Paginator):
         self.show_all = 'all' in request.GET
         self.page_num = page_num
         self.paginator = paginator
@@ -19,13 +22,14 @@ class InlineChangeList(object):
         self.params = dict(request.GET.items())
 
 
-class PaginationFormSetBase(object):
-    queryset = None
-    request = None
+class PaginationFormSetBase:
+    queryset: Optional[QuerySet] = None
+    request: Optional[HttpRequest] = None
     per_page = 20
     pagination_key = 'page'
 
     def get_page_num(self) -> int:
+        assert self.request is not None
         page = self.request.GET.get(self.pagination_key, '1')
         if page.isnumeric() and page > '0':
             return int(page)
@@ -39,6 +43,7 @@ class PaginationFormSetBase(object):
         return paginator.page(1)
 
     def mount_paginator(self, page_num: int = None):
+        assert self.queryset is not None and self.request is not None
         page_num = self.get_page_num() if not page_num else page_num
         self.paginator = Paginator(self.queryset, self.per_page)
         self.page = self.get_page(self.paginator, page_num)

--- a/django_admin_inline_paginator/templatetags/paginated_inline.py
+++ b/django_admin_inline_paginator/templatetags/paginated_inline.py
@@ -7,7 +7,7 @@ register = template.Library()
 
 
 @register.simple_tag
-def modify_pagination_path(full_path, key, value):
+def modify_pagination_path(full_path: str, key: str, value: str) -> str:
     get_params = full_path
     if get_params.find('?') > -1:
         get_params = get_params[get_params.find('?')+1:]

--- a/django_admin_inline_paginator/tests/admin_unit_test.py
+++ b/django_admin_inline_paginator/tests/admin_unit_test.py
@@ -1,7 +1,7 @@
 import unittest
 from django.contrib.admin.views.main import ChangeList
 
-from django_admin_inline_paginator.admin import InlineChangeList, PaginationFormSetBase, PaginationInline
+from django_admin_inline_paginator.admin import InlineChangeList, PaginationFormSetBase
 
 
 class TestInlineChangeList(unittest.TestCase):
@@ -42,16 +42,4 @@ class TestPaginationFormSetBase(unittest.TestCase):
         pass
 
     def test_init(self):
-        pass
-
-
-class TestPaginationInline(unittest.TestCase):
-
-    def test_default_values(self):
-        self.assertEqual(PaginationInline.template, 'admin/edit_inline/tabular_paginated.html')
-        self.assertEqual(PaginationInline.per_page, 20)
-        self.assertEqual(PaginationInline.extra, 0)
-        self.assertEqual(PaginationInline.can_delete, False)
-
-    def test_get_formset(self):
         pass

--- a/example/app/example/models.py
+++ b/example/app/example/models.py
@@ -8,7 +8,7 @@ class Country(Model):
     active = BooleanField(default=True)
 
     def __str__(self):
-        return f'{self.name}'
+        return self.name
 
     class Meta:
         verbose_name = 'Country'
@@ -21,7 +21,7 @@ class State(Model):
     active = BooleanField(default=True)
 
     def __str__(self):
-        return f'{self.name}'
+        return self.name
 
     class Meta:
         verbose_name = 'State'
@@ -34,7 +34,7 @@ class Region(Model):
     active = BooleanField(default=True)
 
     def __str__(self):
-        return f'{self.name}'
+        return self.name
 
     class Meta:
         verbose_name = 'Region'

--- a/example/conf/settings.py
+++ b/example/conf/settings.py
@@ -11,6 +11,7 @@ https://docs.djangoproject.com/en/2.2/ref/settings/
 """
 
 import os
+from typing import List
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -25,7 +26,7 @@ SECRET_KEY = 'wa@as#_q*^g$i1u4bvl*_=8v=s6=(_4)$&g3d73g&z%$$gj94*'
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS: List[str] = []
 
 
 # Application definition


### PR DESCRIPTION
Issue: closes #14 

## What I did

- [x] Added type hints and assertions required to make the modules pass `mypy` type checks
- [x] Removed unused tests and non-existing import on a test case
- [x] Removed redundant string interpolations

## How to test

Install and run `mypy  django_admin_inline_paginator`, it should pass without reporting any type errors. 