### PR TITLE
conditional import ugettext(deprecated in version 4.0) -> gettext

### DIFF
--- a/django_admin_inline_paginator/apps.py
+++ b/django_admin_inline_paginator/apps.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
 from django.apps import AppConfig
-from django.utils.translation import ugettext_lazy as _
+try:
+    from django.utils.translation import ugettext_lazy as _
+except ImportError:
+    from django.utils.translation import gettext_lazy as _
 
 
 class DjangoAdminInlinePaginatorConfig(AppConfig):

--- a/django_admin_inline_paginator/tests/apps_test.py
+++ b/django_admin_inline_paginator/tests/apps_test.py
@@ -1,6 +1,9 @@
 import unittest
 from django.apps import AppConfig
-from django.utils.translation import ugettext_lazy as _
+try:
+    from django.utils.translation import ugettext_lazy as _
+except ImportError:
+    from django.utils.translation import gettext_lazy as _
 from django_admin_inline_paginator.apps import DjangoAdminInlinePaginatorConfig
 
 


### PR DESCRIPTION
ugettext is deprecated.