### PR TITLE
Fix pagination keys in preserved filters querystring

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,10 @@ pip install django-admin-inline-paginator
 
     ```
     @register(YourModel)
-    class YourModelAdmin(ModelAdmin):
+    class YourModelAdmin(InlineModelPaginated, ModelAdmin):
         fields = (...)
         inlines = (ModelWithFKAdminInline, )
+        inline_pagination_keys = (ModelWithFKAdminInline.paginated_key, )
         model = YourModel
     ```
 
@@ -64,9 +65,10 @@ pip install django-admin-inline-paginator
     
     ```
     @register(YourModel)
-    class YourModelAdmin(ModelAdmin):
+    class YourModelAdmin(InlineModelPaginated, ModelAdmin):
         fields = (...)
         inlines = (ModelWithFKAdminInline, AnotherModelWithFKInline)
+        inline_pagination_keys = (ModelWithFKAdminInline.pagination_key, AnotherModelWithFKInline.pagination_key)
         model = YourModel
     ```
 

--- a/django_admin_inline_paginator/admin.py
+++ b/django_admin_inline_paginator/admin.py
@@ -4,6 +4,7 @@ from django.contrib.admin.views.main import ChangeList
 from django.core.paginator import Paginator
 from django.http import HttpRequest
 from django.db.models import QuerySet
+from django.utils.http import urlencode
 
 
 class InlineChangeList:
@@ -77,3 +78,17 @@ class TabularInlinePaginated(TabularInline):
         PaginationFormSet.request = request
         PaginationFormSet.per_page = self.per_page
         return PaginationFormSet
+
+
+class InlineModelPaginated:
+    inline_pagination_keys = ('page', )
+
+    def get_preserved_filters(self, request):
+        return '&'.join(filter(None, [
+            super().get_preserved_filters(request),
+            urlencode({
+                key: request.GET.get(key)
+                for key in request.GET.keys()
+                if key in self.inline_pagination_keys
+            })
+        ]))

--- a/example/app/example/admin.py
+++ b/example/app/example/admin.py
@@ -1,5 +1,5 @@
 from django.contrib.admin import ModelAdmin, register
-from django_admin_inline_paginator.admin import TabularInlinePaginated
+from django_admin_inline_paginator.admin import TabularInlinePaginated, InlineModelPaginated
 
 from .models import Country, Region, State
 
@@ -18,7 +18,8 @@ class RegionAdminInline(TabularInlinePaginated):
 
 
 @register(Country)
-class CountryAdmin(ModelAdmin):
+class CountryAdmin(InlineModelPaginated, ModelAdmin):
     fields = ('name', 'active')
     inlines = (StateAdminInline, RegionAdminInline)
+    inline_pagination_keys = (StateAdminInline.pagination_key, RegionAdminInline.pagination_key)
     model = Country


### PR DESCRIPTION
Hi! 

May fix this issue #20 

**Problem**

Changes from the 2nd page onwards are not saved.

**Solution**

It appears that model change form doesn't contain the action url with pagination key. So when we click on save then Django lose the pagination context and save the wrong formset (default is for page 1).

Inline pagination needs context on each requests:
https://github.com/shinneider/django-admin-inline-paginator/blob/53bf9162dfc724386f03dc3ecdcddbb1e3d07b70/django_admin_inline_paginator/admin.py#L31-L37

Django preserves only `_changelist_filters` :
https://github.com/django/django/blob/f6f0699d01f5840437bfd236c76c797943ef8edc/django/contrib/admin/options.py#L1039-L1055

**Discussions**

- I'm not convinced by the use of `inline_pagination_keys` in `ModelAdmin`.
- `InlineModelPaginated` naming